### PR TITLE
ENH: Do not upgrade OS; BUG: Do not pipe to grep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ compiler:
   - clang
   - gcc
 
-before_install:
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo add-apt-repository ppa:george-edison55/cmake-3.x -y; fi
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew update; fi
-
-install:
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo apt-get upgrade; fi
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew upgrade cmake; fi
-
 before_script:
   - export OMP_NUM_THREADS=2
   - echo $OMP_NUM_THREADS
@@ -29,7 +21,7 @@ before_script:
 
 script:
   - cmake ../SuperElastix/SuperBuild
-  - make | grep -v '^-- Installing'
+  - make -j2
 
 after_success:
   - cd SuperElastix-build


### PR DESCRIPTION
Previously, we had to upgrade OS images to get CMake. This is not necessary anymore, and build was stalled by upgrade procedure. Piping to grep swallows the exit code of the make program, so even a failed build would always exit with 0.